### PR TITLE
Guard optional DOM nodes and Matterport initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-*.sw[p-o]
+*.sw?

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -16,7 +16,10 @@ export default class EventManager {
 
     // ui
     if (app && app.cameraHandlers) {
-      document.getElementById("view-mode-button").addEventListener('click', app.cameraHandlers.toggleViewMode.bind(app.cameraHandlers));
+      const viewModeButton = document.getElementById("view-mode-button");
+      if (viewModeButton) {
+        viewModeButton.addEventListener('click', app.cameraHandlers.toggleViewMode.bind(app.cameraHandlers));
+      }
     }
     // pointer events
     if (app && app.pointerHandlers) {
@@ -31,7 +34,10 @@ export default class EventManager {
       document.addEventListener('touchend', this.handleTouchEnd.bind(this));
     }
 
-    document.getElementById("full-screen-button").addEventListener('click', this.handleFullscreenToggle.bind(this));
+    const fullScreenButton = document.getElementById("full-screen-button");
+    if (fullScreenButton) {
+      fullScreenButton.addEventListener('click', this.handleFullscreenToggle.bind(this));
+    }
     // document.getElementById("guide-toggle-button").addEventListener('click', this.handleGuideToggle.bind(this));
     // document.getElementById("free-explore-toggle-button").addEventListener('click', this.handleGuideToggle.bind(this));
     // document.getElementById("audio-on-button").addEventListener('click', this.audioMute.bind(this));
@@ -51,7 +57,7 @@ export default class EventManager {
   _disableTouchMoveOnNextPrev() {
     const nextButton = document.getElementById("next-button");
     const prevButton = document.getElementById("prev-button");
-    const buttons = [nextButton, prevButton];
+    const buttons = [nextButton, prevButton].filter(Boolean);
 
     let touchStartY = 0;
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -48,20 +48,26 @@ if (space.type === "spaces") {
 if (!tourGuidedAutoplay) {
     const autoplayCheck = document.getElementById("autoplay");
     if (autoplayCheck) {
-        autoplayCheck.checked = false; 
+        autoplayCheck.checked = false;
     }
 
     const tourUiButtons = document.getElementById("tour-ui-buttons");
-    tourUiButtons.style.transition = "opacity 0.5s";
-    tourUiButtons.style.opacity = 1;
+    if (tourUiButtons) {
+        tourUiButtons.style.transition = "opacity 0.5s";
+        tourUiButtons.style.opacity = 1;
+    }
 }
 
 if (!defaultShowText) {
     const wordsCheckbox = document.getElementById("words");
     const tourUiNavpoint = document.getElementById("tour-ui-navpoint");
-    wordsCheckbox.checked = false; 
-    tourUiNavpoint.style.transition = "opacity 0.5s";
-    tourUiNavpoint.style.opacity = 0;
+    if (wordsCheckbox) {
+        wordsCheckbox.checked = false;
+    }
+    if (tourUiNavpoint) {
+        tourUiNavpoint.style.transition = "opacity 0.5s";
+        tourUiNavpoint.style.opacity = 0;
+    }
 }
 
 // Canvas

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -265,12 +265,16 @@ export default class App {
 
     } else {
       const nodeLoadingScreen = document.getElementById("node-loading-screen");
-      nodeLoadingScreen.classList.remove("hidden"); 
+      if (nodeLoadingScreen) {
+        nodeLoadingScreen.classList.remove("hidden");
+      }
 
       this.loadNode(node, () => {
         // callback after loading:
         // hide loading screen
-        nodeLoadingScreen.classList.add("hidden"); 
+        if (nodeLoadingScreen) {
+          nodeLoadingScreen.classList.add("hidden");
+        }
 
         if (this.areAllFacesLoaded(node)) {
           // perform navigation
@@ -282,7 +286,9 @@ export default class App {
           console.error("Loading had error:", node);
 
           // Handle the scenario where faces couldn't be loaded (e.g., show an error message)
-          nodeLoadingScreen.classList.add("hidden"); 
+          if (nodeLoadingScreen) {
+            nodeLoadingScreen.classList.add("hidden");
+          }
         }
       });
     }

--- a/src/components/TransitionManager.js
+++ b/src/components/TransitionManager.js
@@ -45,9 +45,14 @@ class TransitionManager {
 
         // Extract the space ID from the src URL
         let spaceId;
-        if (tour) {
-            spaceId = tour.tour_data.spaces[tourSpaceActiveIdx].mpid;
-        } else {
+        const tourSpaces = tour && tour.tour_data && tour.tour_data.spaces;
+        if (Array.isArray(tourSpaces) && tourSpaces[tourSpaceActiveIdx]) {
+            spaceId = tourSpaces[tourSpaceActiveIdx].mpid;
+        } else if (tour) {
+            console.warn('Matterport tour missing space data, falling back to space src.');
+        }
+
+        if (!spaceId) {
 
             const url = new URL(space.src);
             spaceId = url.searchParams.get('m');
@@ -86,7 +91,7 @@ class TransitionManager {
 
         await this.connectToMatterportSDK('y1bwseat2gwueyxz59987z4ud', options);
 
-        if (tour.tour_data.sceneGraph && tour.tour_data.sceneGraph.length) {
+        if (tour && tour.tour_data && tour.tour_data.sceneGraph && tour.tour_data.sceneGraph.length) {
 
             this.sceneGraph = [];
             this.loader = new GLTFLoader();
@@ -97,7 +102,7 @@ class TransitionManager {
             this.loader.setDRACOLoader(dracoLoader);
 
             this.initThreeJsCanvas();
-       }
+        }
     }
 
     async connectToMatterportSDK(sdkKey, options) {


### PR DESCRIPTION
## Summary
- guard optional tour UI elements before applying autoplay and text defaults
- handle Matterport spaces without tour metadata and skip loader setup safely
- avoid binding UI listeners or toggling loading overlays when DOM nodes are absent
- replace the invalid Vim swap file pattern with a valid glob in `.gitignore`

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cce424cfb483278d3da89f18453e8e