### PR TITLE
Fix guided tour activation and env cube updates

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -170,7 +170,7 @@ const initialStore = {
     textures: {},
     materialCache: {},
     tour,
-    tourGuidedMode: tour && 'spaces' in tour && tour.spaces.length > 0,
+    tourGuidedMode: Array.isArray(tour?.tour_data?.spaces) && tour.tour_data.spaces.length > 0,
     tourGuidedAutoplay,
     tourSpaceActiveIdx: 0,
     tourPointActiveIdx: 0,

--- a/src/components/AudioManager.js
+++ b/src/components/AudioManager.js
@@ -96,7 +96,7 @@ export default class AudioManager {
   playNarration(name) {
     // If there's a current narration, fade it out
     if (this.currentNarration) {
-      this.fadeOut(this.currentNarration, 50, 0.2, this.playSound(name)); // 50ms interval, 0.01 volume decrement
+      this.fadeOut(this.currentNarration, 50, 0.2, () => this.playSound(name)); // 50ms interval, 0.01 volume decrement
     } else {
       this.playSound(name);
     }
@@ -184,7 +184,7 @@ export default class AudioManager {
       if (elapsed < duration) {
         const ratio = elapsed / duration;
         fromSound.setVolume(fromSoundOptions.volume - (ratio * fromSoundOptions.volume));
-        toSound.setVolume(ratio * fromSoundOptions.volume);
+        toSound.setVolume(ratio * toSoundOptions.volume);
 
         requestAnimationFrame(step);
       } else {

--- a/src/components/EnvCube.js
+++ b/src/components/EnvCube.js
@@ -257,12 +257,26 @@ class EnvCube {
   getVisibleFaces() {
     const { camera } = Store.getState();
     const visibleFaces = [];
+    const cameraPosition = new THREE.Vector3().copy(camera.position);
+    const faceCenter = new THREE.Vector3();
+    const direction = new THREE.Vector3();
+
+    this.group.updateMatrixWorld(true);
 
     this.group.children.forEach((child, i) => {
       if (this.fullResolutionFaces.has(i)) return;
 
-      this.raycaster.setFromCamera(camera.position, camera);
-      const intersects = this.raycaster.intersectObject(child);
+      child.updateMatrixWorld(true);
+      child.getWorldPosition(faceCenter);
+
+      direction.subVectors(faceCenter, cameraPosition);
+      if (direction.lengthSq() === 0) {
+        return;
+      }
+
+      direction.normalize();
+      this.raycaster.set(cameraPosition, direction);
+      const intersects = this.raycaster.intersectObject(child, false);
 
       if (intersects.length > 0) {
         visibleFaces.push(i);
@@ -344,7 +358,15 @@ export default class EnvCubeManager {
     // Calculate the movement direction in world space
     const movementDirectionWorld = cameraLerpTarget.clone().sub(cameraPosition).normalize();
 
-    this.envCubeOutgoing.materials.forEach(material => {
+    this.envCubeOutgoing.group.updateMatrixWorld(true);
+
+    this.envCubeOutgoing.materials.forEach((material, faceI) => {
+      const mesh = this.envCubeOutgoing.group.children[faceI];
+      if (!material.uniforms || !mesh) {
+        return;
+      }
+
+      mesh.updateMatrixWorld(true);
 
       // Get the face normal direction in world space
       const faceNormal = new THREE.Vector3();
@@ -370,7 +392,7 @@ export default class EnvCubeManager {
       }
 
       // Transform the face normal from local space to world space
-      const faceNormalMatrix = new THREE.Matrix3().getNormalMatrix(this.envCubeOutgoing.group.matrixWorld);
+      const faceNormalMatrix = new THREE.Matrix3().getNormalMatrix(mesh.matrixWorld);
       faceNormal.applyMatrix3(faceNormalMatrix).normalize();
 
       // Calculate the dot product between the movement direction and the face normal
@@ -386,6 +408,8 @@ export default class EnvCubeManager {
       } else {
         stretchDirection.set(0, Math.sign(projectedMovement.y), 0);
       }
+
+      material.uniforms.movementDirection.value.copy(stretchDirection);
 
     });
   }


### PR DESCRIPTION
## Summary
- ensure guided tours initialize when tour data exposes nested space lists
- correct env cube face visibility detection and shader movement direction updates
- fix narration fade timing and background crossfade target volumes

## Testing
- npm run build *(fails: missing optional dependency dotenv required by webpack config)*

------
https://chatgpt.com/codex/tasks/task_e_68cd15efbd2883279e08f3a713ecb056