### PR TITLE
Add guard for loading indicator updates

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -1,4 +1,5 @@
-import * as THREE from 'three'
+import * as THREE from 'three';
+
 import Space from './Space';
 
 import {

--- a/src/components/TransitionManager.js
+++ b/src/components/TransitionManager.js
@@ -1,5 +1,6 @@
 // TransitionManager.js
-import * as THREE from 'three'
+import * as THREE from 'three';
+
 import { setupSdk } from '@matterport/sdk';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader';

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,9 @@ store.loadingManager.onProgress = (url, loaded, total) => {
   const loadingText = document.getElementById("loading-text-notification-percent")
 
   // Update the text content with the loading percentage
-  loadingText.textContent =  percentComplete + '%';
+  if (loadingText) {
+    loadingText.textContent =  percentComplete + '%';
+  }
 };
 
 if (space.type === "matterport") {
@@ -125,7 +127,9 @@ if (space.type === "matterport") {
     const progress = timestamp - start;
     const percentComplete = Math.min(100, Math.floor((progress / 600) * 100));
 
-    loadingText.textContent = percentComplete + '%';
+    if (loadingText) {
+      loadingText.textContent = percentComplete + '%';
+    }
 
     if (percentComplete < 100) {
       requestAnimationFrame(animateLoading);


### PR DESCRIPTION
## Summary
- add missing semicolons to the THREE imports so bundlers treat them consistently as ES modules
- guard loading progress updates so absent DOM nodes do not throw runtime errors

## Testing
- `npm run build` *(fails: missing optional dependency `dotenv` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd74f4db30832793aa3bd4efc0940f